### PR TITLE
Updates/1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 #Alces Flight Appliance Documentation
-[![Documentation Status](https://readthedocs.org/projects/alces-flight-appliance-docs/badge/?version=aws)](http://alces-flight-appliance-docs.readthedocs.org/en/aws/?badge=aws) [![Documentation Status](https://readthedocs.org/projects/alces-flight-appliance-docs/badge/?version=openstack)](http://alces-flight-appliance-docs.readthedocs.org/en/aws/?badge=openstack)
+[![Documentation Status](https://readthedocs.org/projects/alces-flight-appliance-docs/badge/?version=latest)](http://alces-flight-appliance-docs.readthedocs.org/en/aws/?badge=latest)
 
 
 Documentation to support deployment and usage of Alces Flight Appliances
 
-* [Read the AWS documentation](http://alces-flight-appliance-docs.readthedocs.org/en/aws/)
-* [Read the OpenStack documentation](http://alces-flight-appliance-docs.readthedocs.org/en/openstack/)
+* [Read the documentation](http://alces-flight-appliance-docs.readthedocs.org/en/latest/)

--- a/docs/source/getting-started/environment-usage/environment_usage.rst
+++ b/docs/source/getting-started/environment-usage/environment_usage.rst
@@ -9,7 +9,6 @@ Tutorials and basic demonstrations of Alces research compute environment capabil
 HPC/scheduler environments
 --------------------------
 
-
 * :ref:`Run an interactive application <run-an-interactive-application>`
 * :ref:`Run an MPI job over multiple nodes <run-an-mpi-job>`
 * :ref:`Run a graphical application <run-a-graphical-application>`
@@ -17,8 +16,6 @@ HPC/scheduler environments
 
 Galaxy research compute environments
 ------------------------------------
-
-.. toctree::
 
 * :ref:`Run a basic Galaxy job <run-a-basic-galaxy-job>`
 * :ref:`Run a FastQ Galaxy job <run-a-fastq-galaxy-job>`

--- a/docs/source/getting-started/environment-usage/gridware-howto/run-mpi-hpl.rst
+++ b/docs/source/getting-started/environment-usage/gridware-howto/run-mpi-hpl.rst
@@ -18,8 +18,7 @@ These can either be installed manually, or via Depot installation:
 
 .. code:: bash
 
-    alces gridware depot fetch https://s3-eu-west-1.amazonaws.com/packages.alces-software.com/depots/hpl
-    alces gridware depot enable hpl 
+    alces gridware depot install benchmark
 
 For more information on Gridware packages and depots - please visit the :ref:`working with Gridware packages<working-with-gridware-applications>` and :ref:`working with depots<working-with-gridware-depots>` guides.
 

--- a/docs/source/getting-started/environment-usage/gridware-howto/run-mpi-imb.rst
+++ b/docs/source/getting-started/environment-usage/gridware-howto/run-mpi-imb.rst
@@ -17,8 +17,7 @@ These can either be installed manually, or via Depot installation:
 
 .. code:: bash
 
-    alces gridware depot fetch https://s3-eu-west-1.amazonaws.com/packages.alces-software.com/depots/benchmark
-    alces gridware depot enable benchmark
+    alces gridware depot install benchmark
 
 For more information on Gridware packages and depots - please visit the :ref:`working with Gridware packages<working-with-gridware-applications>` and :ref:`working with depots<working-with-gridware-depots>` guides.
 

--- a/docs/source/getting-started/environment-usage/gridware-howto/working-with-gridware-applications.rst
+++ b/docs/source/getting-started/environment-usage/gridware-howto/working-with-gridware-applications.rst
@@ -10,7 +10,6 @@ Prerequisites
 
 -  `SGE compute node environment deployed <cfn-deploy-sge-spot-cluster>`_
 -  At least 1 compute node deployed
--  *Optional*: Application Manager Appliance deployed
 
 Overview
 --------
@@ -18,7 +17,7 @@ Alces Gridware provides users with a simple method to install many applications,
 
 Using the *modules* environment with the Alces Gridware utility enables you to install multiple versions of applications if required, traditionally this is not possible without advanced configuration.
 
-Gridware can install be installed from any host within your environment, in the case more powerful compute hosts are available - you may wish to compile applications on compute hosts. The default configuration shares Gridware applications across the ``/opt/gridware`` shared NFS directory from either the cluster login node or the Application Manager appliance, depending on your installation type.
+Gridware can install be installed from any host within your environment, in the case more powerful compute hosts are available - you may wish to compile applications on compute hosts. The default configuration shares Gridware applications across the ``/opt/gridware`` shared NFS directory from the cluster login node.
 
 Viewing available Gridware
 --------------------------

--- a/docs/source/getting-started/environment-usage/gridware-howto/working-with-gridware-depots.rst
+++ b/docs/source/getting-started/environment-usage/gridware-howto/working-with-gridware-depots.rst
@@ -16,59 +16,156 @@ Optionally - you can create your own Gridware Depots for later use.
 Prerequisites
 -------------
 
--  `SGE compute node environment deployed <cfn-deploy-sge-spot-cluster>`__
--  *Optional*: Application Manager Appliance deployed
+-  Alces Flight Compute environment deployed
 
 Depot Usage
 -----------
 Using ``alces gridware depot --help`` from your cluster login node will provide a usage page, however the basic Gridware Depot functions available include: 
 
--  ``fetch`` - download a Depot from a remote URL and unpack
+-  ``install`` - install a Gridware Depot from the list of available Depots
 -  ``enable`` - enable the previously depot you previously used ``fetch`` on for global usage
 -  ``disable`` - mark a depot as unavailable for use
 
 Fetching a Depot
 ----------------
-From the login node of your environment, as an appropriate user - fetch one of the publicly available Gridware Depots - such as the ``benchmark`` depot: 
+From the login node of your environment, as an administrator user - fetch one of the publicly available Gridware Depots - such as the ``benchmark`` depot: 
 
 .. code:: bash
 
-    [alces@login1(hpc1) ~]$ alces gridware depot fetch https://s3-eu-west-1.amazonaws.com/packages.alces-software.com/depots/benchmark
+    [alces@login1(flight-cluster) ~]$ alces gridware depot install benchmark
+    Installing depot: benchmark
     
-     > Fetching depot
-            Metadata ... OK
-             Content ... OK
+     > Initializing depot: benchmark
+          Initialize ... OK
+    
+    Importing mpi-openmpi-1.8.5-el7.tar.gz
+    
+     > Fetching archive
+            Download ... OK
+    
+     > Preparing import
              Extract ... OK
-                Link ... OK
-    Depot 'benchmark' fetched successfully.
-
-Once the Depot has been fetched, enable it for usage across your environment: 
-
-.. code:: bash
-
-    [alces@login1(hpc1) ~]$ alces gridware depot enable benchmark
+              Verify ... OK
     
-     > Enabling depot: benchmark
-              Enable ... OK
-
-The ``benchmark`` depot will now be available in your available application modules: 
+     > Processing mpi/openmpi/1.8.5/gcc-4.8.5
+           Preparing ... OK
+           Importing ... OK
+         Permissions ... OK
+    
+     > Finalizing import
+              Update ... OK
+        Dependencies ... OK
+    
+    Importing libs-atlas-3.10.2-el7.tar.gz
+    
+     > Fetching archive
+            Download ... OK
+    
+     > Preparing import
+             Extract ... OK
+              Verify ... OK
+    
+     > Processing libs/atlas/3.10.2/gcc-4.8.5
+           Preparing ... OK
+           Importing ... OK
+         Permissions ... OK
+    
+     > Finalizing import
+              Update ... OK
+        Dependencies ... OK
+    
+    Importing apps-memtester-4.3.0-el7.tar.gz
+    
+     > Fetching archive
+            Download ... OK
+    
+     > Preparing import
+             Extract ... OK
+              Verify ... OK
+    
+     > Processing apps/memtester/4.3.0/gcc-4.8.5
+           Preparing ... OK
+           Importing ... OK
+         Permissions ... OK
+    
+     > Finalizing import
+              Update ... OK
+        Dependencies ... OK
+    
+    Importing apps-iozone-3.420-el7.tar.gz
+    
+     > Fetching archive
+            Download ... OK
+    
+     > Preparing import
+             Extract ... OK
+              Verify ... OK
+    
+     > Processing apps/iozone/3.420/gcc-4.8.5
+           Preparing ... OK
+           Importing ... OK
+         Permissions ... OK
+    
+     > Finalizing import
+              Update ... OK
+        Dependencies ... OK
+    
+    Importing apps-imb-4.0-el7.tar.gz
+    
+     > Fetching archive
+            Download ... OK
+    
+     > Preparing import
+             Extract ... OK
+              Verify ... OK
+    
+     > Processing apps/imb/4.0/gcc-4.8.5+openmpi-1.8.5
+           Preparing ... OK
+           Importing ... OK
+         Permissions ... OK
+    
+     > Finalizing import
+              Update ... OK
+        Dependencies ... OK
+    
+    Importing apps-hpl-2.1-el7.tar.gz
+    
+     > Fetching archive
+            Download ... OK
+    
+     > Preparing import
+             Extract ... OK
+              Verify ... OK
+    
+     > Processing apps/hpl/2.1/gcc-4.8.5+openmpi-1.8.5+atlas-3.10.2
+           Preparing ... OK
+           Importing ... OK
+         Permissions ... OK
+    
+     > Finalizing import
+              Update ... OK
+        Dependencies ... OK
+    
+Once the Depot has been installed, it will be immediately available for use throughout your environment: 
 
 .. code:: bash
 
-    [alces@login1(hpc1) ~]$ alces module avail
+    [alces@login1(flight-cluster) ~]$ module avail
     ---  /opt/gridware/benchmark/el7/etc/modules  ---
+      apps/hpl/2.1/gcc-4.8.5+openmpi-1.8.5+atlas-3.10.2
       apps/imb/4.0/gcc-4.8.5+openmpi-1.8.5
       apps/iozone/3.420/gcc-4.8.5
       apps/memtester/4.3.0/gcc-4.8.5
       compilers/gcc/system
+      libs/atlas/3.10.2/gcc-4.8.5
       libs/gcc/system
       mpi/openmpi/1.8.5/gcc-4.8.5
       null
     ---  /opt/gridware/local/el7/etc/modules  ---
-      apps/fah/6.34/bin
       compilers/gcc/system
       libs/gcc/system
       null
     ---  /opt/clusterware/etc/modules  ---
+      null
+      services/aws
       services/gridscheduler
-

--- a/docs/source/getting-started/environment-usage/run-a-graphical-application.rst
+++ b/docs/source/getting-started/environment-usage/run-a-graphical-application.rst
@@ -3,7 +3,7 @@
 Run a graphical application
 ###########################
 
-How to run a graphical application using your ClusterWare environment.
+How to run a graphical application using your Alces Flight Compute environment.
 
 The following guide will detail how to create an Alces GNOME session,
 then run a graphical application from within the graphical session.
@@ -11,8 +11,7 @@ then run a graphical application from within the graphical session.
 Prerequisites
 -------------
 
--  `ClusterWare compute environment
-   deployed <heat-deploy-sgecluster>`__
+-  Alces Flight compute environment deployed
 
 Creating a graphical session
 ----------------------------

--- a/docs/source/getting-started/environment-usage/run-an-interactive-application.rst
+++ b/docs/source/getting-started/environment-usage/run-an-interactive-application.rst
@@ -3,26 +3,25 @@
 Run an interactive application
 ==============================
 
-How to run an interactive application using your ClusterWare
-environment.
+How to run an interactive application using your Alces Flight Compute environment 
 
 The following guide will teach you how to gain an interactive session on a compute node, then run an application interactively
 
 Prerequisites
 -------------
 
--  :ref:`SGE compute node environment deployed <heat-deploy-sge-cluster>`
+- Alces Flight Compute environment deployed 
 -  At least 1 compute node deployed to the environment
--  ``benchmark`` Gridware depot installed
+- ``benchmark`` Gridware depot installed
 
 Running an interactive application
 ----------------------------------
 
-Once access has been gained to the ClusterWare login node - gain an
+Once access has been gained to the Alces Flight login node - gain an
 interactive session on one of the compute nodes, with all of that nodes
 resources using the ``qrsh`` command:
 
-.. code:: bahs
+.. code:: bash 
 
     [alces@login1(clusterware) ~]$ qrsh -pe mpinodes-verbose 1
     Warning: Permanently added '[node1.clusterware.alces.network]:60692,[192.168.150.183]:60692' (ECDSA) to the list of known hosts.

--- a/docs/source/getting-started/environment-usage/run-an-interactive-application.rst
+++ b/docs/source/getting-started/environment-usage/run-an-interactive-application.rst
@@ -25,24 +25,41 @@ resources using the ``qrsh`` command:
 
     [alces@login1(clusterware) ~]$ qrsh -pe mpinodes-verbose 1
     Warning: Permanently added '[node1.clusterware.alces.network]:60692,[192.168.150.183]:60692' (ECDSA) to the list of known hosts.
-                     +++++++++++++++++++++++++++++++++++++++++++++
-                                 Welcome to clusterware
-                              Alces Clusterware (r2016.01)
-                         Based on CentOS Linux 7.2.1511 (Core)
-                     +++++++++++++++++++++++++++++++++++++++++++++
+           `.:/+/
+       ./oooo+`
+     `/oooooo.                       Welcome to flight-cluster
+     /oooooo/
+     ooooooo-  ./o/                Alces Clusterware (r2016.2)
+     +oooooo/`+ooo       Based on CentOS Linux 7.2.1511 (Core)
+     -oooooooooooo
+      :ooooooooooo. `:+:`
+       -+ooooooooo+:ooo`
+        `:ooooooooooooo.                               `.
+          `:+oooooooooo+`                              /o/
+            `-+ooooooooo+-                 :.   .+/   -ooo:
+               .:+oooooooo+-`            .+o: `:ooo  :oooo+
+                  `-/oooooooo/..-....-:/+ooo//oooo+/+ooooo/
+                      ./oooooooo+oooooooooooooooooooooooo/`
+                        .+oooooooooo++oooooooooooooooo+:.
+                          .:/+ooooooo-`..--::::::::-.`
+                                `-:/oo+
+                                   `-.  -[ alces flight ]-
     TIPS:
 
     'module avail'            - show available application environments
     'module add <modulename>' - add a module to your current environment
-
-    'alces session'           - start and manage interactive sessions
+    
     'alces gridware'          - manage software for your environment
     'alces howto'             - guides on how to use your research environment
+    'alces session'           - start and manage interactive sessions
+    'alces storage'           - configure and address storage facilities
     'alces template'          - tailored job script templates
-
+    
     'qstat'                   - show summary of running jobs
     'qsub'                    - submit a job script
     'qdesktop'                - submit an interactive session request
+    
+    'aws help'                - show help for AWS CLI
 
 Once the interactive session has been gained - load the ``memtester``
 Gridware application:

--- a/docs/source/getting-started/environment-usage/run-an-mpi-job.rst
+++ b/docs/source/getting-started/environment-usage/run-an-mpi-job.rst
@@ -12,15 +12,14 @@ nodes.
 Prerequisites
 -------------
 
--  `SGE compute node environment
-   deployed <https://github.com/alces-software/clusterware-deployment-methods/wiki/AWS:-Deploy-an-SGE-on-demand-compute-cluster>`__
+-  Alces Flight Compute environment deployed
 -  2 compute nodes provisioned
 -  ``benchmark`` Gridware depot installed
 
 Running IMB
 -----------
 
-From the ClusterWare environment login node, as either the administrator
+From the Alces Flight Compute environment login node, as either the administrator
 (``alces``) user - or a regular cluster user account - check the ``imb``
 application is available from the Gridware depot:
 

--- a/docs/source/getting-started/environment-usage/run-storage-benchmarks.rst
+++ b/docs/source/getting-started/environment-usage/run-storage-benchmarks.rst
@@ -40,10 +40,10 @@ Prerequisites
 The following prerequisites must have been met in order to follow this
 guide:
 
--  ClusterWare environment deployed
+-  Alces Flight Compute environment deployed
 -  SSH access to the environment
 -  ``benchmark`` GridWare depot installed
--  Administrator account access (``alces`` user)
+-  Administrator account access 
 
 Measuring write performance
 ---------------------------

--- a/docs/source/getting-started/environment-usage/using-openfoam-with-alces-flight-compute.rst
+++ b/docs/source/getting-started/environment-usage/using-openfoam-with-alces-flight-compute.rst
@@ -8,8 +8,7 @@ The following guide will run through the basics of using OpenFOAM together with 
 Prerequisites
 -------------
 
--  `Alces Flight compute environment
-   deployed <heat-deploy-sge-cluster>`__
+-  Alces Flight Compute environment deployed with at least 2 compute nodes
 
 Installing the OpenFOAM Gridware Depot
 --------------------------------------


### PR DESCRIPTION
Updates for ClusterWare v1.5 usage. 

Still to-do: 
- [ ] wait for packages requested for update in `packager-base` to be done
- [ ] change openfoam installation to use `alces gridware install` rather than depot install
- [ ] add VPN set up/usage guide
