### PR TITLE
Document cluster VPN usage

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ We recommend that users wishing to use Flight Appliances have basic Linux skills
    mpiapps/*
    jobschedulers/*
    sge/sge
+   vpn/vpn
    
 .. toctree::
    :maxdepth: 1

--- a/docs/source/vpn/vpn.rst
+++ b/docs/source/vpn/vpn.rst
@@ -3,7 +3,9 @@
 Cluster VPN
 ===========
 
-Your cluster is automatically configured with a Virtual Private Network (VPN) - allowing you to connect your workstation to the cluster network. The Alces Flight Compute VPN uses `OpenVPN <https://openvpn.net/>`_ - so you may wish to use a client that is capable of connecting using OpenVPN configurations. 
+Your cluster is automatically configured with a Virtual Private Network (VPN) - allowing you to connect your workstation to the cluster network. The cluster VPN provides your machine with an IP address that is part of the environment's network, allowing direct communication with compute nodes for high-performance graphical application access and data transfer. All communications exchanged over a VPN are automatically encrypted using a certificate unique to your cluster.
+
+The Alces Flight Compute VPN uses `OpenVPN <https://openvpn.net/>`_ - so you may wish to use a client that is capable of connecting using OpenVPN configurations. 
 
 .. note:: Each Alces Flight Compute cluster you deploy is configured with a separate VPN configuration - so you will need to create new profiles within your client for each Alces Flight Compute environment you create
 
@@ -45,4 +47,4 @@ Your Alces Flight Compute cluster automatically packages the VPN configuration f
 
 You can then obtain the VPN configuration packs either through command-line tools such as `scp`, or through the Alces Flight web page as shown in the ``alces about vpn`` output and connect using the steps provided by your VPN client instructions. 
 
-.. note:: The VPN configuration download web page is only available to users running an Alces Flight Compute *Enterprise* edition cluster
+.. note:: The VPN configuration download web page is only available to users running an Alces Flight Compute *Enterprise* edition cluster. The VPN configuration page available to Alces Flight Compute *Enterprise* edition clusters also includes handy instructions on how to connect using various clients.

--- a/docs/source/vpn/vpn.rst
+++ b/docs/source/vpn/vpn.rst
@@ -10,7 +10,7 @@ Your cluster is automatically configured with a Virtual Private Network (VPN) - 
 Available VPN clients
 ---------------------
 
-There are many VPN clients available, some our favourite clients for each platform include; 
+There are many VPN clients available, some of our favourite clients for each platform include; 
 
 macOS
 `````

--- a/docs/source/vpn/vpn.rst
+++ b/docs/source/vpn/vpn.rst
@@ -1,0 +1,48 @@
+.. _vpn:
+
+Cluster VPN
+===========
+
+Your cluster is automatically configured with a Virtual Private Network (VPN) - allowing you to connect your workstation to the cluster network. The Alces Flight Compute VPN uses `OpenVPN <https://openvpn.net/>`_ - so you may wish to use a client that is capable of connecting using OpenVPN configurations. 
+
+.. note:: Each Alces Flight Compute cluster you deploy is configured with a separate VPN configuration - so you will need to create new profiles within your client for each Alces Flight Compute environment you create
+
+Available VPN clients
+---------------------
+
+There are many VPN clients available, some our favourite clients for each platform include; 
+
+macOS
+`````
+
+* `TunnelBlick <https://tunnelblick.net/>`_
+
+Linux
+`````
+
+* NetworkManager includes support for OpenVPN configurations
+
+Windows
+```````
+
+* `OpenVPN <https://openvpn.net/index.php/open-source/downloads.html>`_
+
+Obtaining VPN configuration
+---------------------------
+
+Your Alces Flight Compute cluster automatically packages the VPN configuration for a number of VPN clients including OpenVPN and TunnelBlick. To view information including download paths for configuration packs, use the ``alces about vpn`` command as per the following example:
+
+.. code:: bash
+
+  [alces@login1(sge) ~]$ alces about vpn
+    VPN configuration path: /opt/clusterware/etc/openvpn/client/clusterware
+         Tarred configuration: /opt/clusterware/etc/openvpn/client/clusterware-openvpn.tgz
+         Zipped configuration: /opt/clusterware/etc/openvpn/client/clusterware-openvpn.zip
+    Tunnelblick configuration: /opt/clusterware/etc/openvpn/client/clusterware-tunnelblick.zip
+            Download web page: https://sge-0a8de07e.cloud.alces.network/vpn/
+     Download access username: vpn
+     Download access password: _JoZrDLJwG
+
+You can then obtain the VPN configuration packs either through command-line tools such as `scp`, or through the Alces Flight web page as shown in the ``alces about vpn`` output and connect using the steps provided by your VPN client instructions. 
+
+.. info:: The VPN configuration download web page is only available to users running an Alces Flight Compute *Enterprise* edition cluster

--- a/docs/source/vpn/vpn.rst
+++ b/docs/source/vpn/vpn.rst
@@ -45,4 +45,4 @@ Your Alces Flight Compute cluster automatically packages the VPN configuration f
 
 You can then obtain the VPN configuration packs either through command-line tools such as `scp`, or through the Alces Flight web page as shown in the ``alces about vpn`` output and connect using the steps provided by your VPN client instructions. 
 
-.. info:: The VPN configuration download web page is only available to users running an Alces Flight Compute *Enterprise* edition cluster
+.. note:: The VPN configuration download web page is only available to users running an Alces Flight Compute *Enterprise* edition cluster


### PR DESCRIPTION
Added a short page detailing the availability of the cluster VPN. Not much exists in the way of content regarding client connection due to the availability of such information on an _Enterprise_ edition Flight Compute cluster. 
- Refs #41 
